### PR TITLE
Export babel

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/babel');


### PR DESCRIPTION
I haven't used your lib yet, but came across it looking for a zero runtime atomic css-in-js solution (similar to the one facebook just demoed @ React Conf, but have not released yet). Going to try it out next hackathon. In the meantime, here's just a quick PR to export `babel` so it can be simply added as `css-zero/babel` instead of `css-zero/src/babel`. I like the macro support, however I've never used it and would rather add the support via a generic `.babelrc` setup.

Cheers!